### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/basen_bms_ble/binary_sensor.py
+++ b/components/basen_bms_ble/binary_sensor.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import BASEN_BMS_BLE_COMPONENT_SCHEMA, CONF_BASEN_BMS_BLE_ID
 
@@ -22,13 +23,13 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = BASEN_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-heart-variant"
+            icon="mdi:battery-heart-variant", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-charging"
+            icon="mdi:battery-charging", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:power-plug"
+            icon="mdi:power-plug", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
     }
 )
@@ -39,6 +40,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/basen_bms_ble/binary_sensor.py
+++ b/components/basen_bms_ble/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import BASEN_BMS_BLE_COMPONENT_SCHEMA, CONF_BASEN_BMS_BLE_ID

--- a/components/basen_bms_ble/switch/__init__.py
+++ b/components/basen_bms_ble/switch/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import BASEN_BMS_BLE_COMPONENT_SCHEMA, CONF_BASEN_BMS_BLE_ID, basen_bms_ble_ns
 
@@ -39,9 +38,8 @@ async def to_code(config):
     for key, address in SWITCHES.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.