### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/basen_bms_ble/basen_bms_ble.h
+++ b/components/basen_bms_ble/basen_bms_ble.h
@@ -175,8 +175,8 @@ class BasenBmsBle : public esphome::ble_client::BLEClientNode, public PollingCom
   } temperatures_[4];
 
   std::vector<uint8_t> frame_buffer_;
-  uint16_t char_notify_handle_;
-  uint16_t char_command_handle_;
+  uint16_t char_notify_handle_{0};
+  uint16_t char_command_handle_{0};
   uint8_t next_command_{5};
 
   float min_cell_voltage_{100.0f};


### PR DESCRIPTION
## Summary

- `char_notify_handle_` and `char_command_handle_` were declared without initializers, leaving them with indeterminate values from construction until the first BLE connection.
- Adds `{0}` in-class member initializers to guarantee a defined state at construction.