### PR TITLE
Add diagnostic entity category to manufacturing_date text sensor

### DIFF
--- a/components/basen_bms_ble/text_sensor.py
+++ b/components/basen_bms_ble/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import BASEN_BMS_BLE_COMPONENT_SCHEMA, CONF_BASEN_BMS_BLE_ID
 
@@ -46,7 +47,8 @@ CONFIG_SCHEMA = BASEN_BMS_BLE_COMPONENT_SCHEMA.extend(
             icon=ICON_DISCHARGING_WARNINGS
         ),
         cv.Optional(CONF_MANUFACTURING_DATE): text_sensor.text_sensor_schema(
-            icon=ICON_MANUFACTURING_DATE
+            icon=ICON_MANUFACTURING_DATE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_BALANCING_CELLS): text_sensor.text_sensor_schema(
             icon=ICON_BALANCING_CELLS


### PR DESCRIPTION
## Summary

- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to `manufacturing_date` sensor (T2)

Follows the pattern established in `esphome-tianpower-bms`.