### PR TITLE
Refactor sensor and binary_sensor schema definitions

### DIFF
--- a/components/basen_bms_ble/binary_sensor.py
+++ b/components/basen_bms_ble/binary_sensor.py
@@ -13,30 +13,33 @@ CONF_BALANCING = "balancing"
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
 
-BINARY_SENSORS = [
-    CONF_BALANCING,
-    CONF_CHARGING,
-    CONF_DISCHARGING,
-]
+# key: binary_sensor_schema kwargs
+BINARY_SENSOR_DEFS = {
+    CONF_BALANCING: {
+        "icon": "mdi:battery-heart-variant",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGING: {
+        "icon": "mdi:battery-charging",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGING: {
+        "icon": "mdi:power-plug",
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+}
 
 CONFIG_SCHEMA = BASEN_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-heart-variant", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:battery-charging", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
-        cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            icon="mdi:power-plug", entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
+        cv.Optional(key): binary_sensor.binary_sensor_schema(**kwargs)
+        for key, kwargs in BINARY_SENSOR_DEFS.items()
     }
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_BASEN_BMS_BLE_ID])
-    for key in BINARY_SENSORS:
+    for key in BINARY_SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await binary_sensor.new_binary_sensor(conf)

--- a/components/basen_bms_ble/sensor.py
+++ b/components/basen_bms_ble/sensor.py
@@ -52,46 +52,6 @@ CONF_MAX_VOLTAGE_CELL = "max_voltage_cell"
 CONF_DELTA_CELL_VOLTAGE = "delta_cell_voltage"
 CONF_AVERAGE_CELL_VOLTAGE = "average_cell_voltage"
 
-CONF_CELL_VOLTAGE_1 = "cell_voltage_1"
-CONF_CELL_VOLTAGE_2 = "cell_voltage_2"
-CONF_CELL_VOLTAGE_3 = "cell_voltage_3"
-CONF_CELL_VOLTAGE_4 = "cell_voltage_4"
-CONF_CELL_VOLTAGE_5 = "cell_voltage_5"
-CONF_CELL_VOLTAGE_6 = "cell_voltage_6"
-CONF_CELL_VOLTAGE_7 = "cell_voltage_7"
-CONF_CELL_VOLTAGE_8 = "cell_voltage_8"
-CONF_CELL_VOLTAGE_9 = "cell_voltage_9"
-CONF_CELL_VOLTAGE_10 = "cell_voltage_10"
-CONF_CELL_VOLTAGE_11 = "cell_voltage_11"
-CONF_CELL_VOLTAGE_12 = "cell_voltage_12"
-CONF_CELL_VOLTAGE_13 = "cell_voltage_13"
-CONF_CELL_VOLTAGE_14 = "cell_voltage_14"
-CONF_CELL_VOLTAGE_15 = "cell_voltage_15"
-CONF_CELL_VOLTAGE_16 = "cell_voltage_16"
-CONF_CELL_VOLTAGE_17 = "cell_voltage_17"
-CONF_CELL_VOLTAGE_18 = "cell_voltage_18"
-CONF_CELL_VOLTAGE_19 = "cell_voltage_19"
-CONF_CELL_VOLTAGE_20 = "cell_voltage_20"
-CONF_CELL_VOLTAGE_21 = "cell_voltage_21"
-CONF_CELL_VOLTAGE_22 = "cell_voltage_22"
-CONF_CELL_VOLTAGE_23 = "cell_voltage_23"
-CONF_CELL_VOLTAGE_24 = "cell_voltage_24"
-CONF_CELL_VOLTAGE_25 = "cell_voltage_25"
-CONF_CELL_VOLTAGE_26 = "cell_voltage_26"
-CONF_CELL_VOLTAGE_27 = "cell_voltage_27"
-CONF_CELL_VOLTAGE_28 = "cell_voltage_28"
-CONF_CELL_VOLTAGE_29 = "cell_voltage_29"
-CONF_CELL_VOLTAGE_30 = "cell_voltage_30"
-CONF_CELL_VOLTAGE_31 = "cell_voltage_31"
-CONF_CELL_VOLTAGE_32 = "cell_voltage_32"
-CONF_CELL_VOLTAGE_33 = "cell_voltage_33"
-CONF_CELL_VOLTAGE_34 = "cell_voltage_34"
-
-CONF_TEMPERATURE_1 = "temperature_1"
-CONF_TEMPERATURE_2 = "temperature_2"
-CONF_TEMPERATURE_3 = "temperature_3"
-CONF_TEMPERATURE_4 = "temperature_4"
-
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 ICON_NOMINAL_CAPACITY = "mdi:battery-50"
@@ -110,505 +70,196 @@ ICON_SERIAL_NUMBER = "mdi:numeric"
 
 UNIT_AMPERE_HOURS = "Ah"
 
-CELLS = [
-    CONF_CELL_VOLTAGE_1,
-    CONF_CELL_VOLTAGE_2,
-    CONF_CELL_VOLTAGE_3,
-    CONF_CELL_VOLTAGE_4,
-    CONF_CELL_VOLTAGE_5,
-    CONF_CELL_VOLTAGE_6,
-    CONF_CELL_VOLTAGE_7,
-    CONF_CELL_VOLTAGE_8,
-    CONF_CELL_VOLTAGE_9,
-    CONF_CELL_VOLTAGE_10,
-    CONF_CELL_VOLTAGE_11,
-    CONF_CELL_VOLTAGE_12,
-    CONF_CELL_VOLTAGE_13,
-    CONF_CELL_VOLTAGE_14,
-    CONF_CELL_VOLTAGE_15,
-    CONF_CELL_VOLTAGE_16,
-    CONF_CELL_VOLTAGE_17,
-    CONF_CELL_VOLTAGE_18,
-    CONF_CELL_VOLTAGE_19,
-    CONF_CELL_VOLTAGE_20,
-    CONF_CELL_VOLTAGE_21,
-    CONF_CELL_VOLTAGE_22,
-    CONF_CELL_VOLTAGE_23,
-    CONF_CELL_VOLTAGE_24,
-    CONF_CELL_VOLTAGE_25,
-    CONF_CELL_VOLTAGE_26,
-    CONF_CELL_VOLTAGE_27,
-    CONF_CELL_VOLTAGE_28,
-    CONF_CELL_VOLTAGE_29,
-    CONF_CELL_VOLTAGE_30,
-    CONF_CELL_VOLTAGE_31,
-    CONF_CELL_VOLTAGE_32,
-    CONF_CELL_VOLTAGE_33,
-    CONF_CELL_VOLTAGE_34,
-]
+CELLS = [f"cell_voltage_{i}" for i in range(1, 35)]
+TEMPERATURES = [f"temperature_{i}" for i in range(1, 5)]
 
-TEMPERATURES = [
-    CONF_TEMPERATURE_1,
-    CONF_TEMPERATURE_2,
-    CONF_TEMPERATURE_3,
-    CONF_TEMPERATURE_4,
-]
+# key: sensor_schema kwargs
+SENSOR_DEFS = {
+    CONF_TOTAL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CURRENT: {
+        "unit_of_measurement": UNIT_AMPERE,
+        "icon": ICON_CURRENT_DC,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DISCHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 2,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CAPACITY_REMAINING: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_CAPACITY_REMAINING,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_STATES_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_STATES_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGING_STATES_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_DISCHARGING_STATES_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_CHARGING_WARNINGS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_WARNINGS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_DISCHARGING_WARNINGS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_DISCHARGING_WARNINGS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_BALANCING_CELLS_BITMASK: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_BALANCING_CELLS_BITMASK,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
+    CONF_STATE_OF_CHARGE: {
+        "unit_of_measurement": UNIT_PERCENT,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_BATTERY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_NOMINAL_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_NOMINAL_CAPACITY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_NOMINAL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_REAL_CAPACITY: {
+        "unit_of_measurement": UNIT_AMPERE_HOURS,
+        "icon": ICON_REAL_CAPACITY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_SERIAL_NUMBER: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_SERIAL_NUMBER,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+    },
+    CONF_CHARGING_CYCLES: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_CHARGING_CYCLES,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+    CONF_MIN_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MIN_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_MAX_CELL_VOLTAGE,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MIN_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MIN_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_MAX_VOLTAGE_CELL: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": ICON_MAX_VOLTAGE_CELL,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_EMPTY,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_DELTA_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 3,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_AVERAGE_CELL_VOLTAGE: {
+        "unit_of_measurement": UNIT_VOLT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 4,
+        "device_class": DEVICE_CLASS_VOLTAGE,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
 
-SENSORS = [
-    CONF_TOTAL_VOLTAGE,
-    CONF_CURRENT,
-    CONF_POWER,
-    CONF_CHARGING_POWER,
-    CONF_DISCHARGING_POWER,
-    CONF_CAPACITY_REMAINING,
-    CONF_CHARGING_STATES_BITMASK,
-    CONF_DISCHARGING_STATES_BITMASK,
-    CONF_CHARGING_WARNINGS_BITMASK,
-    CONF_DISCHARGING_WARNINGS_BITMASK,
-    CONF_BALANCING_CELLS_BITMASK,
-    CONF_STATE_OF_CHARGE,
-    CONF_NOMINAL_CAPACITY,
-    CONF_NOMINAL_VOLTAGE,
-    CONF_REAL_CAPACITY,
-    CONF_SERIAL_NUMBER,
-    CONF_CHARGING_CYCLES,
-    CONF_MIN_CELL_VOLTAGE,
-    CONF_MAX_CELL_VOLTAGE,
-    CONF_MIN_VOLTAGE_CELL,
-    CONF_MAX_VOLTAGE_CELL,
-    CONF_DELTA_CELL_VOLTAGE,
-    CONF_AVERAGE_CELL_VOLTAGE,
-]
+_CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_VOLT,
+    icon=ICON_EMPTY,
+    accuracy_decimals=3,
+    device_class=DEVICE_CLASS_VOLTAGE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+_TEMPERATURE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_CELSIUS,
+    icon=ICON_EMPTY,
+    accuracy_decimals=0,
+    device_class=DEVICE_CLASS_TEMPERATURE,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
 
-# pylint: disable=too-many-function-args
-CONFIG_SCHEMA = BASEN_BMS_BLE_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_TOTAL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            icon=ICON_CURRENT_DC,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DISCHARGING_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CAPACITY_REMAINING): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_CAPACITY_REMAINING,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CHARGING_STATES_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_STATES_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_DISCHARGING_STATES_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_DISCHARGING_STATES_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_CHARGING_WARNINGS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_WARNINGS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_DISCHARGING_WARNINGS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_DISCHARGING_WARNINGS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_BALANCING_CELLS_BITMASK): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_BALANCING_CELLS_BITMASK,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-        cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_PERCENT,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_BATTERY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_NOMINAL_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_NOMINAL_CAPACITY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_NOMINAL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_REAL_CAPACITY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE_HOURS,
-            icon=ICON_REAL_CAPACITY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_SERIAL_NUMBER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_SERIAL_NUMBER,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-        ),
-        cv.Optional(CONF_CHARGING_CYCLES): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_CHARGING_CYCLES,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MIN_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_MAX_CELL_VOLTAGE,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MIN_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MIN_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_MAX_VOLTAGE_CELL): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon=ICON_MAX_VOLTAGE_CELL,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_DELTA_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_AVERAGE_CELL_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=4,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_TEMPERATURE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_1): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_2): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_4): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_6): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_7): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_8): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_9): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_10): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_11): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_12): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_13): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_14): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_15): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_16): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_17): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_18): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_19): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_20): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_21): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_22): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_23): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_24): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_25): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_26): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_27): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_28): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_29): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_30): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_31): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_32): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_33): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CELL_VOLTAGE_34): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
+CONFIG_SCHEMA = (
+    BASEN_BMS_BLE_COMPONENT_SCHEMA.extend(
+        {
+            cv.Optional(key): sensor.sensor_schema(**kwargs)
+            for key, kwargs in SENSOR_DEFS.items()
+        }
+    )
+    .extend({cv.Optional(key): _CELL_VOLTAGE_SCHEMA for key in CELLS})
+    .extend({cv.Optional(key): _TEMPERATURE_SCHEMA for key in TEMPERATURES})
 )
 
 
@@ -624,7 +275,7 @@ async def to_code(config):
             conf = config[key]
             sens = await sensor.new_sensor(conf)
             cg.add(hub.set_cell_voltage_sensor(i, sens))
-    for key in SENSORS:
+    for key in SENSOR_DEFS:
         if key in config:
             conf = config[key]
             sens = await sensor.new_sensor(conf)


### PR DESCRIPTION
Replace flat `SENSORS`/`BINARY_SENSORS` lists and verbose per-entry `CONFIG_SCHEMA` blocks with `SENSOR_DEFS`/`BINARY_SENSOR_DEFS` dicts. `CONFIG_SCHEMA` is now built from a single dict comprehension, making it trivial to add new entities with full kwargs support.

Also replaces individual `CONF_CELL_VOLTAGE_N` / `CONF_TEMPERATURE_N` constants with f-string comprehensions (`CELLS`, `TEMPERATURES`), and introduces shared `_CELL_VOLTAGE_SCHEMA` / `_TEMPERATURE_SCHEMA` variables where applicable.