### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/basen_bms_ble/basen_bms_ble.cpp
+++ b/components/basen_bms_ble/basen_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace basen_bms_ble {
+namespace esphome::basen_bms_ble {
 
 static const char *const TAG = "basen_bms_ble";
 
@@ -769,5 +768,4 @@ std::string BasenBmsBle::discharging_warnings_bits_to_string_(const uint8_t mask
   return values;
 }
 
-}  // namespace basen_bms_ble
-}  // namespace esphome
+}  // namespace esphome::basen_bms_ble

--- a/components/basen_bms_ble/basen_bms_ble.h
+++ b/components/basen_bms_ble/basen_bms_ble.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace basen_bms_ble {
+namespace esphome::basen_bms_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -211,7 +210,6 @@ class BasenBmsBle : public esphome::ble_client::BLEClientNode, public PollingCom
   }
 };
 
-}  // namespace basen_bms_ble
-}  // namespace esphome
+}  // namespace esphome::basen_bms_ble
 
 #endif

--- a/components/basen_bms_ble/switch/basen_switch.cpp
+++ b/components/basen_bms_ble/switch/basen_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace basen_bms_ble {
+namespace esphome::basen_bms_ble {
 
 static const char *const TAG = "basen_bms_ble.switch";
 
@@ -12,5 +11,4 @@ void BasenSwitch::write_state(bool state) {
   // this->parent_->write_register(this->holding_register_, (uint16_t) state);
 }
 
-}  // namespace basen_bms_ble
-}  // namespace esphome
+}  // namespace esphome::basen_bms_ble

--- a/components/basen_bms_ble/switch/basen_switch.h
+++ b/components/basen_bms_ble/switch/basen_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace basen_bms_ble {
+namespace esphome::basen_bms_ble {
 
 class BasenBmsBle;
 class BasenSwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class BasenSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace basen_bms_ble
-}  // namespace esphome
+}  // namespace esphome::basen_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.