### PR TITLE
CI: Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: 0 12 * * *
 
+  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds `workflow_dispatch` to the CI workflow so it can be triggered manually via the GitHub Actions UI.