### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -444,7 +444,7 @@ jobs:
       - name: Validate example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > secrets.yaml
           for YAML in esp*.yaml; do
             esphome -s external_components_source components config $YAML
           done
@@ -452,7 +452,7 @@ jobs:
       - name: Validate test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > tests/secrets.yaml
           for YAML in tests/esp*.yaml; do
             esphome -s external_components_source ../components config $YAML
           done
@@ -495,7 +495,7 @@ jobs:
       - name: Compile example configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > secrets.yaml
           for YAML in esp*faker.yaml; do
             esphome -s external_components_source components compile $YAML
           done
@@ -505,7 +505,7 @@ jobs:
       - name: Compile test configurations
         run: |
           . venv/bin/activate
-          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > tests/secrets.yaml
+          echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password\nbms0_mac_address: 70:3e:97:07:c0:3e\nbms1_mac_address: 70:3e:97:07:c0:3f" > tests/secrets.yaml
           esphome -s external_components_source ../components compile tests/esp32c6-compatibility-test.yaml
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ wifi_password: MY_WIFI_PASSWORD
 mqtt_host: MY_MQTT_HOST
 mqtt_username: MY_MQTT_USERNAME
 mqtt_password: MY_MQTT_PASSWORD
+
+bms0_mac_address: MY_BMS_MAC_ADDRESS
+# The esp32-ble-example-multiple-devices.yaml additionally expects a bms1_mac_address.
+bms1_mac_address: MY_BMS_MAC_ADDRESS_1
 EOF
 
 # Validate the configuration, create a binary, upload it, and start logs

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -4,8 +4,6 @@ substitutions:
   bms1: "${name} bms1"
   device_description: "Monitor a Basen Battery Management System via BLE"
   external_components_source: github://syssi/esphome-basen-bms@main
-  bms0_mac_address: A4:C1:38:27:48:9A
-  bms1_mac_address: A4:C1:38:27:48:9B
 
 esphome:
   name: ${name}
@@ -59,9 +57,9 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${bms0_mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
-  - mac_address: ${bms1_mac_address}
+  - mac_address: !secret bms1_mac_address
     id: client1
 
 basen_bms_ble:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: basen-bms-ble
   device_description: "Monitor a Basen Battery Management System via BLE"
   external_components_source: github://syssi/esphome-basen-bms@main
-  mac_address: A4:C1:38:27:48:9A
 
 esphome:
   name: ${name}
@@ -50,7 +49,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 basen_bms_ble:

--- a/tests/esp32-ble-client.yaml
+++ b/tests/esp32-ble-client.yaml
@@ -1,7 +1,6 @@
 substitutions:
   name: basen-bms-ble
   device_description: "Establish a BLE client connection"
-  mac_address: A4:C1:38:27:48:9A
 
 esphome:
   name: ${name}
@@ -40,7 +39,7 @@ api:
 esp32_ble_tracker:
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 switch:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -37,7 +37,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: A4:C1:38:27:48:9A
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 basen_bms_ble:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret bms0_mac_address` directly in `ble_client:` instead of using a hard-coded YAML substitution
- Update CI to generate the required secret keys with example values
- Document the new secrets in the README installation section