### PR TITLE
Add online_status sensor with unavailability tracking

### DIFF
--- a/components/basen_bms_ble/basen_bms_ble.cpp
+++ b/components/basen_bms_ble/basen_bms_ble.cpp
@@ -106,8 +106,6 @@ void BasenBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
     case ESP_GATTC_DISCONNECT_EVT: {
       this->node_state = espbt::ClientState::IDLE;
 
-      // this->publish_state_(this->voltage_sensor_, NAN);
-
       if (this->char_notify_handle_ != 0) {
         auto status = esp_ble_gattc_unregister_for_notify(this->parent()->get_gattc_if(),
                                                           this->parent()->get_remote_bda(), this->char_notify_handle_);

--- a/components/basen_bms_ble/basen_bms_ble.cpp
+++ b/components/basen_bms_ble/basen_bms_ble.cpp
@@ -12,6 +12,7 @@
 namespace esphome::basen_bms_ble {
 
 static const char *const TAG = "basen_bms_ble";
+static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
 static const uint16_t BASEN_BMS_SERVICE_UUID = 0xFA00;
 static const uint16_t BASEN_BMS_NOTIFY_CHARACTERISTIC_UUID = 0xFA01;   // handle 0x12
@@ -232,6 +233,7 @@ void BasenBmsBle::assemble_(const uint8_t *data, uint16_t length) {
 }
 
 void BasenBmsBle::update() {
+  this->track_online_status_();
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
     return;
@@ -252,6 +254,7 @@ void BasenBmsBle::update() {}
 #endif  // USE_ESP32
 
 void BasenBmsBle::on_basen_bms_ble_data(const std::vector<uint8_t> &data) {
+  this->reset_online_status_tracker_();
   uint8_t frame_type = data[2];
 
   switch (frame_type) {
@@ -580,6 +583,7 @@ void BasenBmsBle::decode_protect_ic_data_(const std::vector<uint8_t> &data) {
 void BasenBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "BasenBmsBle:");
 
+  LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
   LOG_BINARY_SENSOR("", "Balancing", this->balancing_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
@@ -652,6 +656,56 @@ void BasenBmsBle::dump_config() {  // NOLINT(google-readability-function-size,re
   LOG_TEXT_SENSOR("", "Discharging warnings", this->discharging_warnings_text_sensor_);
   LOG_TEXT_SENSOR("", "Manufacturing Date", this->manufacturing_date_text_sensor_);
   LOG_TEXT_SENSOR("", "Balancing cells", this->balancing_cells_text_sensor_);
+}
+
+void BasenBmsBle::track_online_status_() {
+  if (this->no_response_count_ < MAX_NO_RESPONSE_COUNT)
+    this->no_response_count_++;
+  if (this->no_response_count_ == MAX_NO_RESPONSE_COUNT) {
+    this->publish_device_unavailable_();
+    this->no_response_count_++;
+  }
+}
+
+void BasenBmsBle::reset_online_status_tracker_() {
+  this->no_response_count_ = 0;
+  this->publish_state_(this->online_status_binary_sensor_, true);
+}
+
+void BasenBmsBle::publish_device_unavailable_() {
+  this->publish_state_(this->online_status_binary_sensor_, false);
+  this->publish_state_(this->total_voltage_sensor_, NAN);
+  this->publish_state_(this->current_sensor_, NAN);
+  this->publish_state_(this->power_sensor_, NAN);
+  this->publish_state_(this->charging_power_sensor_, NAN);
+  this->publish_state_(this->discharging_power_sensor_, NAN);
+  this->publish_state_(this->capacity_remaining_sensor_, NAN);
+  this->publish_state_(this->charging_states_bitmask_sensor_, NAN);
+  this->publish_state_(this->discharging_states_bitmask_sensor_, NAN);
+  this->publish_state_(this->charging_warnings_bitmask_sensor_, NAN);
+  this->publish_state_(this->discharging_warnings_bitmask_sensor_, NAN);
+  this->publish_state_(this->balancing_cells_bitmask_sensor_, NAN);
+  this->publish_state_(this->state_of_charge_sensor_, NAN);
+  this->publish_state_(this->nominal_capacity_sensor_, NAN);
+  this->publish_state_(this->nominal_voltage_sensor_, NAN);
+  this->publish_state_(this->real_capacity_sensor_, NAN);
+  this->publish_state_(this->serial_number_sensor_, NAN);
+  this->publish_state_(this->charging_cycles_sensor_, NAN);
+  this->publish_state_(this->min_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->max_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->min_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->max_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->delta_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->average_cell_voltage_sensor_, NAN);
+  for (auto &cell : this->cells_)
+    this->publish_state_(cell.cell_voltage_sensor_, NAN);
+  for (auto &temp : this->temperatures_)
+    this->publish_state_(temp.temperature_sensor_, NAN);
+  this->publish_state_(this->charging_states_text_sensor_, "Offline");
+  this->publish_state_(this->discharging_states_text_sensor_, "Offline");
+  this->publish_state_(this->charging_warnings_text_sensor_, "Offline");
+  this->publish_state_(this->discharging_warnings_text_sensor_, "Offline");
+  this->publish_state_(this->balancing_cells_text_sensor_, "Offline");
 }
 
 void BasenBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/basen_bms_ble/basen_bms_ble.h
+++ b/components/basen_bms_ble/basen_bms_ble.h
@@ -29,6 +29,9 @@ class BasenBmsBle :
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
+  void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
+    online_status_binary_sensor_ = online_status_binary_sensor;
+  }
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
@@ -133,6 +136,7 @@ class BasenBmsBle :
   void on_basen_bms_ble_data(const std::vector<uint8_t> &data);
 
  protected:
+  binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *balancing_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
@@ -182,6 +186,7 @@ class BasenBmsBle :
   std::vector<uint8_t> frame_buffer_;
   uint16_t char_notify_handle_{0};
   uint16_t char_command_handle_{0};
+  uint8_t no_response_count_{0};
   uint8_t next_command_{5};
   uint8_t mosfet_status_{0xFF};
 
@@ -192,6 +197,9 @@ class BasenBmsBle :
   uint8_t max_voltage_cell_{0};
   uint8_t min_voltage_cell_{0};
 
+  void publish_device_unavailable_();
+  void reset_online_status_tracker_();
+  void track_online_status_();
   void assemble_(const uint8_t *data, uint16_t length);
   void decode_status_data_(const std::vector<uint8_t> &data);
   void decode_general_info_data_(const std::vector<uint8_t> &data);

--- a/components/basen_bms_ble/binary_sensor.py
+++ b/components/basen_bms_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import BASEN_BMS_BLE_COMPONENT_SCHEMA, CONF_BASEN_BMS_BLE_ID
 
@@ -12,9 +12,14 @@ CODEOWNERS = ["@syssi"]
 CONF_BALANCING = "balancing"
 CONF_CHARGING = "charging"
 CONF_DISCHARGING = "discharging"
+CONF_ONLINE_STATUS = "online_status"
 
 # key: binary_sensor_schema kwargs
 BINARY_SENSOR_DEFS = {
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_BALANCING: {
         "icon": "mdi:battery-heart-variant",
         "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -73,6 +73,9 @@ basen_bms_ble:
 binary_sensor:
   - platform: basen_bms_ble
     basen_bms_ble_id: bms0
+    online_status:
+      name: "online status"
+      device_id: device0
     balancing:
       name: "balancing"
       device_id: device0
@@ -85,6 +88,9 @@ binary_sensor:
 
   - platform: basen_bms_ble
     basen_bms_ble_id: bms1
+    online_status:
+      name: "online status"
+      device_id: device1
     balancing:
       name: "balancing"
       device_id: device1

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -59,6 +59,8 @@ basen_bms_ble:
 
 binary_sensor:
   - platform: basen_bms_ble
+    online_status:
+      name: "online status"
     balancing:
       name: "balancing"
     charging:

--- a/tests/components/basen_bms_ble/basen_bms_ble_test.cpp
+++ b/tests/components/basen_bms_ble/basen_bms_ble_test.cpp
@@ -227,6 +227,180 @@ TEST(BasenBmsBleBaleancingTest, BalancingCells) {
   EXPECT_EQ(cells.state, "8, 16");
 }
 
+// ── Online status tracker ─────────────────────────────────────────────────────
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, ReachesThreshold) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, DoesNotRepeatAfterThreshold) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+
+  bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+}
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, ResetRestoresOnlineStatus) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+
+  bms.reset_online_status_tracker_();
+  EXPECT_TRUE(online_status.state);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, CanRetriggerAfterReset) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  bms.reset_online_status_tracker_();
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, ValidFrameResetsCounter) {
+  TestableBasenBmsBle bms;
+
+  for (int i = 0; i < 5; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 5);
+
+  bms.on_basen_bms_ble_data(STATUS_FRAME);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(BasenBmsBleOnlineStatusTrackerTest, NotYetAtThresholdStaysOnline) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  for (int i = 0; i < 9; i++)
+    bms.track_online_status_();
+
+  EXPECT_TRUE(online_status.state);
+}
+
+// ── publish_device_unavailable_ ───────────────────────────────────────────────
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, SetsOnlineStatusFalse) {
+  TestableBasenBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  bms.publish_device_unavailable_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, SetsNumericSensorsToNAN) {
+  TestableBasenBmsBle bms;
+  sensor::Sensor total_voltage, current, power, charging_power, discharging_power;
+  sensor::Sensor capacity_remaining, state_of_charge, nominal_capacity, nominal_voltage;
+  sensor::Sensor real_capacity, charging_cycles;
+  bms.set_total_voltage_sensor(&total_voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_capacity_remaining_sensor(&capacity_remaining);
+  bms.set_state_of_charge_sensor(&state_of_charge);
+  bms.set_nominal_capacity_sensor(&nominal_capacity);
+  bms.set_nominal_voltage_sensor(&nominal_voltage);
+  bms.set_real_capacity_sensor(&real_capacity);
+  bms.set_charging_cycles_sensor(&charging_cycles);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(total_voltage.state));
+  EXPECT_TRUE(std::isnan(current.state));
+  EXPECT_TRUE(std::isnan(power.state));
+  EXPECT_TRUE(std::isnan(charging_power.state));
+  EXPECT_TRUE(std::isnan(discharging_power.state));
+  EXPECT_TRUE(std::isnan(capacity_remaining.state));
+  EXPECT_TRUE(std::isnan(state_of_charge.state));
+  EXPECT_TRUE(std::isnan(nominal_capacity.state));
+  EXPECT_TRUE(std::isnan(nominal_voltage.state));
+  EXPECT_TRUE(std::isnan(real_capacity.state));
+  EXPECT_TRUE(std::isnan(charging_cycles.state));
+}
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, SetsCellAndTempSensorsToNAN) {
+  TestableBasenBmsBle bms;
+  sensor::Sensor cell0, cell1, temp0, temp1;
+  bms.set_cell_voltage_sensor(0, &cell0);
+  bms.set_cell_voltage_sensor(1, &cell1);
+  bms.set_temperature_sensor(0, &temp0);
+  bms.set_temperature_sensor(1, &temp1);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(cell0.state));
+  EXPECT_TRUE(std::isnan(cell1.state));
+  EXPECT_TRUE(std::isnan(temp0.state));
+  EXPECT_TRUE(std::isnan(temp1.state));
+}
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, SetsDynamicTextSensorsToOffline) {
+  TestableBasenBmsBle bms;
+  text_sensor::TextSensor charging_states, discharging_states, charging_warnings;
+  text_sensor::TextSensor discharging_warnings, balancing_cells;
+  bms.set_charging_states_text_sensor(&charging_states);
+  bms.set_discharging_states_text_sensor(&discharging_states);
+  bms.set_charging_warnings_text_sensor(&charging_warnings);
+  bms.set_discharging_warnings_text_sensor(&discharging_warnings);
+  bms.set_balancing_cells_text_sensor(&balancing_cells);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(charging_states.state, "Offline");
+  EXPECT_EQ(discharging_states.state, "Offline");
+  EXPECT_EQ(charging_warnings.state, "Offline");
+  EXPECT_EQ(discharging_warnings.state, "Offline");
+  EXPECT_EQ(balancing_cells.state, "Offline");
+}
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, LeavesStaticTextSensorsUnchanged) {
+  TestableBasenBmsBle bms;
+  text_sensor::TextSensor manufacturing_date;
+  manufacturing_date.publish_state("2021.11.17");
+  bms.set_manufacturing_date_text_sensor(&manufacturing_date);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(manufacturing_date.state, "2021.11.17");
+}
+
+TEST(BasenBmsBlePublishDeviceUnavailableTest, NullSensorsDoNotCrash) {
+  TestableBasenBmsBle bms;
+
+  EXPECT_NO_FATAL_FAILURE(bms.publish_device_unavailable_());
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(BasenBmsBleSafetyTest, NullSensorsDoNotCrash) {

--- a/tests/components/basen_bms_ble/common.h
+++ b/tests/components/basen_bms_ble/common.h
@@ -16,6 +16,10 @@ class TestableBasenBmsBle : public BasenBmsBle {
   void set_mosfet_status(uint8_t status) { this->mosfet_status_ = status; }
   uint8_t get_mosfet_status() const { return this->mosfet_status_; }
   using BasenBmsBle::build_frame_;
+  using BasenBmsBle::track_online_status_;
+  using BasenBmsBle::reset_online_status_tracker_;
+  using BasenBmsBle::publish_device_unavailable_;
+  uint8_t get_no_response_count() const { return no_response_count_; }
   uint16_t last_write_reg{0};
   uint8_t last_write_value{0};
 };

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -55,10 +55,11 @@ class TestSensorLists:
 
 class TestBinarySensorDefs:
     def test_binary_sensor_defs_completeness(self):
+        assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_BALANCING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_CHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 3
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 4
 
 
 class TestTextSensors:


### PR DESCRIPTION
## Summary

- Adds `online_status` binary sensor (`device_class: connectivity`, `entity_category: diagnostic`)
- After 10 consecutive `update()` cycles without a valid BMS frame, marks the device unavailable: `online_status` → false, all numeric sensors → NaN, dynamic text sensors → "Offline"
- Static identity sensor (`manufacturing_date`) is left unchanged
- Integrates `track_online_status_()` at the start of `update()` and `reset_online_status_tracker_()` at the entry of `on_basen_bms_ble_data()`

## Test plan

- [x] C++ unit tests: `BasenBmsBleOnlineStatusTrackerTest` (6 tests) and `BasenBmsBlePublishDeviceUnavailableTest` (6 tests) — all 48 tests pass
- [x] pytest schema validation passes (4 binary sensor defs)
- [x] `esp32-ble-example.yaml` and `esp32-ble-example-multiple-devices.yaml` updated with `online_status` sensor