### PR TITLE
Fix OOB reads in assemble_() on malformed BLE notifications

### DIFF
--- a/components/basen_bms_ble/basen_bms_ble.cpp
+++ b/components/basen_bms_ble/basen_bms_ble.cpp
@@ -192,6 +192,9 @@ void BasenBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
 }
 
 void BasenBmsBle::assemble_(const uint8_t *data, uint16_t length) {
+  if (data == nullptr || length == 0)
+    return;
+
   if (this->frame_buffer_.size() > MAX_RESPONSE_SIZE) {
     ESP_LOGW(TAG, "Maximum response size exceeded");
     this->frame_buffer_.clear();
@@ -206,6 +209,12 @@ void BasenBmsBle::assemble_(const uint8_t *data, uint16_t length) {
 
   if (this->frame_buffer_.back() == BASEN_PKT_END_2) {
     const uint8_t *raw = &this->frame_buffer_[0];
+
+    if (this->frame_buffer_.size() < 8) {
+      ESP_LOGW(TAG, "Frame too short (%zu bytes), discarding", this->frame_buffer_.size());
+      this->frame_buffer_.clear();
+      return;
+    }
 
     uint16_t data_len = raw[3];
     uint16_t frame_len = 4 + data_len + 4;


### PR DESCRIPTION
## Summary

Two out-of-bounds read paths in `BasenBmsBle::assemble_()`:

- **Missing null/zero-length guard**: `data[0]` was accessed unconditionally for the preamble check, causing undefined behaviour when ESP-IDF delivers a zero-length GATTC notification (same class of bug fixed in esphome-ant-bms#175).

- **OOB read on `raw[3]`**: `data_len = raw[3]` was reached whenever `frame_buffer_.back() == BASEN_PKT_END_2` (0x0A), which requires only 1 byte in the buffer. The minimum valid frame is 8 bytes (`4` header + `0` data + `4` trailer). A short buffer whose last byte happens to be `0x0A` — e.g. a BLE chunk boundary — triggers an out-of-bounds read before the frame-length validation at line 212 can catch it.

## Fix

1. Add `if (data == nullptr || length == 0) return;` guard at the top of `assemble_()`.
2. Add `if (this->frame_buffer_.size() < 8)` guard before accessing `raw[3]`.

## Test plan

- [ ] Normal frame parsing still works (no regression)
- [ ] Zero-length GATTC notification no longer crashes
- [ ] Short buffer ending with `0x0A` is discarded cleanly with a log warning